### PR TITLE
Fix handling of gpu_mem to match raspi-config

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,0 @@
-This is an application which allows the configuration of Raspberry Pi system settings..
-
-To build, run autogen.sh, then ./configure and make.
-Use sudo make install to install data files.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # rc_gui
 
-GUI for configuring Raspberry Pi settings.
-(Including Raspberry Pi Desktop for PC/Mac).
+GUI for configuring Raspberry Pi settings. (Including Raspberry Pi Desktop for PC/Mac).
 
 Uses the command-line equivalent, [`raspi-config`](https://github.com/RPi-Distro/raspi-config), internally for some operations.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# rc_gui
+
+GUI for configuring Raspberry Pi settings.
+(Including Raspberry Pi Desktop for PC/Mac).
+
+Uses the command-line equivalent, [`raspi-config`](https://github.com/RPi-Distro/raspi-config), internally for some operations.
+
+## Building
+
+Install pre-requisites:
+
+```bash
+sudo apt update
+sudo apt install autoconf libglib2.0-dev autogen libtool intltool libgtk2.0-dev
+```
+
+Configure and build:
+
+```bash
+./autogen.sh
+./configure
+make
+```
+
+Install data files:
+
+```bash
+sudo make install
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Uses the command-line equivalent, [`raspi-config`](https://github.com/RPi-Distro
 
 ## Building
 
-Install pre-requisites:
+Install prerequisites:
 
 ```bash
 sudo apt update

--- a/src/rc_gui.c
+++ b/src/rc_gui.c
@@ -274,10 +274,10 @@ static int get_gpu_mem (void)
         mem = get_status (GET_GPU_MEM_256);
 
     if (mem == 0) mem = get_status (GET_GPU_MEM);
-    if (mem == 0 && get_total_mem() > 1008)
-        mem = 76;
-    else
+    if (mem == 0 && get_total_mem() <= 1008)
         mem = 64;
+    else
+        mem = 76;
     return mem;
 }
 

--- a/src/rc_gui.c
+++ b/src/rc_gui.c
@@ -274,8 +274,10 @@ static int get_gpu_mem (void)
         mem = get_status (GET_GPU_MEM_256);
 
     if (mem == 0) mem = get_status (GET_GPU_MEM);
-    if (mem == 0) mem = get_status (DEFAULT_GPU_MEM);
-    if (mem == 0) mem = 64;
+    if (mem == 0 && get_total_mem() > 1008)
+        mem = 76;
+    else
+        mem = 64;
     return mem;
 }
 


### PR DESCRIPTION
`rc_gui` currently handles setting `gpu_mem` slightly differently to raspi-config:

- If there is no `gpu_mem` specified in `config.txt`, `raspi-config` will assume the default `gpu_mem` setting of 64MB
     (PR https://github.com/RPi-Distro/raspi-config/pull/131 pending to change this to the actual firmware default of 64 or 76MB, which depends on memory size)
- If there is no `gpu_mem` specified in `config.txt`, `rc_gui` will call `vcgencmd get_mem gpu` and default to that

The `rc_gui` version of the algorithm suffers from a minor problem (apart from the fact it doesn't match `raspi-config`):  if the user has previously booted with a `gpu_mem` setting in config.txt (for example 320MB), then removed that line (perhaps using a previous run of `rc_gui`), then run `rc_gui`, it will prompt the user with a "default" of e.g. 320MB, not what the firmware actually defaults to in the case of nothing being specified in `config.txt`, i.e. 64 or 76MB. This PR fixes up `rc_gui` so that it behaves the same as `raspi-config` with https://github.com/RPi-Distro/raspi-config/pull/131 applied.