### PR TITLE
Update VNC tooltip

### DIFF
--- a/data/rc_gui.ui
+++ b/data/rc_gui.ui
@@ -1006,7 +1006,7 @@
                       <object class="GtkSwitch" id="sw_vnc">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
-                        <property name="tooltip-text" translatable="yes">Enable remote access to this Pi using RealVNC</property>
+                        <property name="tooltip-text" translatable="yes">Enable remote access to this Pi using VNC</property>
                         <accessibility>
                           <relation type="labelled-by" target="label23"/>
                         </accessibility>


### PR DESCRIPTION
Fixes https://github.com/raspberrypi/bookworm-feedback/issues/35

Disclaimer: I'm not sure if there might be any other changes that need to be made at the same time? (I've also not tried building this). But I do know that in the latest 32-bit Bookworm image with all apt-updates installed (`apt show` says rc-gui is at version 1.71), it still says "Turn on to enable remote access using RealVNC" when I mouse-hover over the VNC radio-button.

Oh, which I've just spotted doesn't actually match the text I've edited here. Curioser and curioser :thinking: 