### PR TITLE
Replace UI captions that mention RealVNC to VNC

### DIFF
--- a/data/rc_gui.ui
+++ b/data/rc_gui.ui
@@ -1006,7 +1006,7 @@
                       <object class="GtkSwitch" id="sw_vnc">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
-                        <property name="tooltip-text" translatable="yes">Enable remote access to this Pi using RealVNC</property>
+                        <property name="tooltip-text" translatable="yes">Enable remote access to this Pi using VNC</property>
                         <accessibility>
                           <relation type="labelled-by" target="label23"/>
                         </accessibility>

--- a/po/de.po
+++ b/po/de.po
@@ -310,12 +310,12 @@ msgid "VNC:"
 msgstr "VNC:"
 
 #: data/rc_gui.ui:1075
-msgid "Enable remote access to this Pi using RealVNC"
-msgstr "Fernzugriff zu diesem Pi über RealVNC aktivieren"
+msgid "Enable remote access to this Pi using VNC"
+msgstr "Fernzugriff zu diesem Pi über VNC aktivieren"
 
 #: data/rc_gui.ui:1094
-msgid "Disable remote access to this Pi using RealVNC"
-msgstr "Fernzugriff zu diesem Pi über RealVNC deaktivieren"
+msgid "Disable remote access to this Pi using VNC"
+msgstr "Fernzugriff zu diesem Pi über VNC deaktivieren"
 
 #: data/rc_gui.ui:1125
 msgid "SPI:"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -355,7 +355,7 @@ msgid "VNC:"
 msgstr "VNC:"
 
 #: ../data/rc_gui.ui.h:46
-msgid "Enable remote access to this Pi using RealVNC"
+msgid "Enable remote access to this Pi using VNC"
 msgstr "Turn on to enable remote access using VNC"
 
 #: ../data/rc_gui.ui.h:47
@@ -633,8 +633,8 @@ msgstr "Password Required"
 #~ msgid "Disable remote access to this Pi via SSH"
 #~ msgstr "Disable remote access to this Pi via SSH"
 
-#~ msgid "Disable remote access to this Pi using RealVNC"
-#~ msgstr "Disable remote access to this Pi using RealVNC"
+#~ msgid "Disable remote access to this Pi using VNC"
+#~ msgstr "Disable remote access to this Pi using VNC"
 
 #~ msgid "Disable the automatic loading of the SPI kernel module"
 #~ msgstr "Disable the automatic loading of the SPI kernel module"

--- a/po/hy.po
+++ b/po/hy.po
@@ -292,12 +292,12 @@ msgid "VNC:"
 msgstr "VNC:"
 
 #: ../data/rc_gui.ui.h:56
-msgid "Enable remote access to this Pi using RealVNC"
-msgstr "Միացնել RealVNC-ի միջոցով հեռավար հասանելիությունը այս սարքին"
+msgid "Enable remote access to this Pi using VNC"
+msgstr "Միացնել VNC-ի միջոցով հեռավար հասանելիությունը այս սարքին"
 
 #: ../data/rc_gui.ui.h:57
-msgid "Disable remote access to this Pi using RealVNC"
-msgstr "Անջատել RealVNC-ի միջոցով հեռավար հասանելիությունը այս սարքին"
+msgid "Disable remote access to this Pi using VNC"
+msgstr "Անջատել VNC-ի միջոցով հեռավար հասանելիությունը այս սարքին"
 
 #: ../data/rc_gui.ui.h:58
 msgid "SPI:"

--- a/po/it.po
+++ b/po/it.po
@@ -445,13 +445,13 @@ msgstr "VNC:"
 
 # tooltip
 #: ../data/rc_gui.ui.h:60
-msgid "Enable remote access to this Pi using RealVNC"
-msgstr "Abilita l'accesso remoto a questo Pi usando RealVNC"
+msgid "Enable remote access to this Pi using VNC"
+msgstr "Abilita l'accesso remoto a questo Pi usando VNC"
 
 # tooltip
 #: ../data/rc_gui.ui.h:61
-msgid "Disable remote access to this Pi using RealVNC"
-msgstr "Disabilita l'accesso remoto a questo Pi usando RealVNC"
+msgid "Disable remote access to this Pi using VNC"
+msgstr "Disabilita l'accesso remoto a questo Pi usando VNC"
 
 #: ../data/rc_gui.ui.h:62
 msgid "SPI:"

--- a/po/ja.po
+++ b/po/ja.po
@@ -375,8 +375,8 @@ msgid "VNC:"
 msgstr "VNC:"
 
 #: ../data/rc_gui.ui.h:47
-msgid "Enable remote access to this Pi using RealVNC"
-msgstr "このPiへのRealVNCでのリモートアクセスを有効にします"
+msgid "Enable remote access to this Pi using VNC"
+msgstr "このPiへのVNCでのリモートアクセスを有効にします"
 
 #: ../data/rc_gui.ui.h:48
 msgid "SPI:"
@@ -664,8 +664,8 @@ msgstr "パスワードが必要です"
 #~ msgid "Disable remote access to this Pi via SSH"
 #~ msgstr "このPiへのSSHでのリモートアクセスを無効にします"
 
-#~ msgid "Disable remote access to this Pi using RealVNC"
-#~ msgstr "このPiへのRealVNCでのリモートアクセスを無効にします"
+#~ msgid "Disable remote access to this Pi using VNC"
+#~ msgstr "このPiへのVNCでのリモートアクセスを無効にします"
 
 #~ msgid "Disable the automatic loading of the SPI kernel module"
 #~ msgstr "SPIカーネルモジュールの自動読み込みを無効にします"

--- a/po/ko.po
+++ b/po/ko.po
@@ -351,8 +351,8 @@ msgid "VNC:"
 msgstr "VNC:"
 
 #: ../data/rc_gui.ui.h:46
-msgid "Enable remote access to this Pi using RealVNC"
-msgstr "RealVNC 원격 액세스 활성화"
+msgid "Enable remote access to this Pi using VNC"
+msgstr "VNC 원격 액세스 활성화"
 
 #: ../data/rc_gui.ui.h:47
 msgid "SPI:"
@@ -627,8 +627,8 @@ msgstr "스크린을 비우지 않음"
 msgid "Disable remote access to this Pi via SSH"
 msgstr "SSH 원격 액세스 비활성화"
 
-msgid "Disable remote access to this Pi using RealVNC"
-msgstr "RealVNC 원격 액세스 비활성화"
+msgid "Disable remote access to this Pi using VNC"
+msgstr "VNC 원격 액세스 비활성화"
 
 msgid "Disable the automatic loading of the SPI kernel module"
 msgstr "SPI 커널 모듈 자동 로드 비활성화"

--- a/po/nb.no
+++ b/po/nb.no
@@ -280,12 +280,12 @@ msgid "VNC:"
 msgstr "VNC:"
 
 #: ../data/rc_gui.ui.h:52
-msgid "Enable remote access to this Pi using RealVNC"
-msgstr "Skru på ekstern tilgang til denne Pi-en gjennom RealVNC"
+msgid "Enable remote access to this Pi using VNC"
+msgstr "Skru på ekstern tilgang til denne Pi-en gjennom VNC"
 
 #: ../data/rc_gui.ui.h:53
-msgid "Disable remote access to this Pi using RealVNC"
-msgstr "Skru av ekstern tilgang til denne Pi-en gjennom RealVNC"
+msgid "Disable remote access to this Pi using VNC"
+msgstr "Skru av ekstern tilgang til denne Pi-en gjennom VNC"
 
 #: ../data/rc_gui.ui.h:54
 msgid "SPI:"

--- a/po/pl.po
+++ b/po/pl.po
@@ -305,12 +305,12 @@ msgid "VNC:"
 msgstr "VNC:"
 
 #: data/rc_gui.ui:1075
-msgid "Enable remote access to this Pi using RealVNC"
-msgstr "Włącz dostęp zdalny do tego Pi za pomocą RealVNC"
+msgid "Enable remote access to this Pi using VNC"
+msgstr "Włącz dostęp zdalny do tego Pi za pomocą VNC"
 
 #: data/rc_gui.ui:1094
-msgid "Disable remote access to this Pi using RealVNC"
-msgstr "Wyłącz dostęp zdalny do tego Pi za pomocą RealVNC"
+msgid "Disable remote access to this Pi using VNC"
+msgstr "Wyłącz dostęp zdalny do tego Pi za pomocą VNC"
 
 #: data/rc_gui.ui:1125
 msgid "SPI:"

--- a/po/sk.po
+++ b/po/sk.po
@@ -291,12 +291,12 @@ msgid "VNC:"
 msgstr "VNC:"
 
 #: ../data/rc_gui.ui.h:56
-msgid "Enable remote access to this Pi using RealVNC"
-msgstr "Zapnúť vzdialený prístup k tomuto Pi prostredníctvom RealVNC"
+msgid "Enable remote access to this Pi using VNC"
+msgstr "Zapnúť vzdialený prístup k tomuto Pi prostredníctvom VNC"
 
 #: ../data/rc_gui.ui.h:57
-msgid "Disable remote access to this Pi using RealVNC"
-msgstr "Vypnúť vzdialený prístup k tomuto Pi prostredníctvom RealVNC"
+msgid "Disable remote access to this Pi using VNC"
+msgstr "Vypnúť vzdialený prístup k tomuto Pi prostredníctvom VNC"
 
 #: ../data/rc_gui.ui.h:58
 msgid "SPI:"


### PR DESCRIPTION
RealVNC is no longer the only implementation being used, so make the captions generic.